### PR TITLE
Fix subsection header behavior

### DIFF
--- a/woosterthesis.cls
+++ b/woosterthesis.cls
@@ -462,8 +462,19 @@
 					##1
 				}
 			}
+			{}
+		}%
+				\def\sectionmark##1{%
+			\markright {
+				{% removed MakeUpperCase - JB
+					\ifnum \c@secnumdepth >\z@
+						\thesection. \ %
+					\fi
+					##1
+        				}
+        			}
+        		}
 		}
-	}
 \fi
 \def\ps@myheadings{%
 	\let\@oddfoot\@empty\let\@evenfoot\@empty


### PR DESCRIPTION
This is an attempt to fix issue https://github.com/jbreitenbucher/exampleis/issues/8 by including subsections into headers. Changes have been tested locally with pdfLaTeX and on Overleaf.

Behavior prior to this PR:
![image](https://github.com/user-attachments/assets/bffefba9-5355-4297-8e75-7bb9f4ab8b52)

Behavior after changes:
![image](https://github.com/user-attachments/assets/4a1ad9eb-81c0-42ed-83d7-6e36e667475b)
